### PR TITLE
Yet another performance fix

### DIFF
--- a/src/monitcollector/models.py
+++ b/src/monitcollector/models.py
@@ -195,6 +195,8 @@ class Service(models.Model):
 
 # Service type=5
 class System(Service):
+    # TODO: put measurements in separate rows, then collect them instead of
+    #   JSON list manipulation
     server = models.OneToOneField('Server')
     date_last = models.PositiveIntegerField(null=True)
     date = models.TextField(null=True)

--- a/src/monitcollector/templates/monitcollector/server.html
+++ b/src/monitcollector/templates/monitcollector/server.html
@@ -84,18 +84,32 @@
         var point_size = 1.5;
         var stroke_width = 1;
         var update_period = 1000*{{monit_update_period}};
-        var data_load = [];
         var dates = {{system.date}};
         var date_objs = [];
         for(var i = 0; i < dates.length; i++) {
             date_objs.push(new Date(dates[i] * 1000));
         }
-        var y1 = {{system.load_avg01}};
-        var y2 = {{system.load_avg05}};
-        var y3 = {{system.load_avg15}};
+
+        var data_load = {{ system_load_zip }};
         for (var i = 0; i < dates.length; i++) {
-            data_load.push([date_objs[i], y1[i], y2[i], y3[i]]);
+            //data_load.push([date_objs[i], y1[i], y2[i], y3[i]]);
+            data_load[i].unshift(date_objs[i]);
         }
+
+        var data_cpu = {{ system_cpu_zip }};
+        //var ymax = 1.2*Math.max.apply(null, y1);
+        for (i = 0; i < dates.length; i++) {
+            //data_cpu.push([date_objs[i], y1[i], y2[i], y3[i]]);
+            data_cpu[i].unshift(date_objs[i]);
+        }
+
+        var data_mem = {{ system_memory_zip }};
+        //var ymax = 1.2*Math.max.apply(null, y1);
+        for (i = 0; i < dates.length; i++) {
+            //data_mem.push([date_objs[i], y1[i], y2[i] / 1.e6, y3[i], y4[i] / 1.e6]);
+            data_mem[i].unshift(date_objs[i]);
+        }
+
         var graph_load = new Dygraph(document.getElementById("graph_load"), data_load,
             {
                 legend: 'always', // show always
@@ -116,14 +130,7 @@
                 }
             });
         set_linewidth(graph_load, data_load);
-        var data_cpu = [];
-        y1 = {{system.cpu_user}};
-        y2 = {{system.cpu_system}};
-        y3 = {{system.cpu_wait}};
-        //var ymax = 1.2*Math.max.apply(null, y1);
-        for (i = 0; i < dates.length; i++) {
-            data_cpu.push([date_objs[i], y1[i], y2[i], y3[i]]);
-        }
+
         var graph_cpu = new Dygraph(document.getElementById("graph_cpu"), data_cpu,
             {
                 legend: 'always', // show always
@@ -145,15 +152,7 @@
                 }
             });
         set_linewidth(graph_cpu, data_cpu);
-        var data_mem = [];
-        y1 = {{system.memory_percent}};
-        y2 = {{system.memory_kilobyte}};
-        y3 = {{system.swap_percent}};
-        var y4 = {{system.swap_kilobyte}};
-        //var ymax = 1.2*Math.max.apply(null, y1);
-        for (i = 0; i < dates.length; i++) {
-            data_mem.push([date_objs[i], y1[i], y2[i] / 1.e6, y3[i], y4[i] / 1.e6]);
-        }
+
         var graph_mem = new Dygraph(document.getElementById("graph_mem"), data_mem,
             {
                 legend: 'always', // show always
@@ -175,6 +174,7 @@
                 }
             });
         set_linewidth(graph_mem, data_mem);
+
         window.intervalId = setInterval(function() {
             $.post("{% url 'monitcollector.views.load_system_data' server.id %}", function(data) {
                 var date = new Date(JSON.parse(data.date)*1000.);

--- a/src/monitcollector/views.py
+++ b/src/monitcollector/views.py
@@ -69,7 +69,7 @@ def server(request, server_id):
                 'monit_update_period': monit_update_period
             }
         )
-    except:
+    except Server.DoesNotExist:
         return render(
             request,
             'monitcollector/dashboard.html',
@@ -82,7 +82,7 @@ def process(request, server_id, process_name):
     server = Server.objects.get(id=server_id)
     process = server.process_set.get(name=process_name)
     return render(request, 'monitcollector/process.html',{'enable_buttons': enable_buttons, 'process_found': True, 'server': server, 'process': process, 'monit_update_period': monit_update_period})
-  except ObjectDoesNotExist:
+  except Server.DoesNotExist:
     return render(request, 'monitcollector/process.html',{'process_found': False})
 
 @staff_member_required

--- a/src/monitcollector/views.py
+++ b/src/monitcollector/views.py
@@ -1,3 +1,6 @@
+import json
+import requests
+
 from django.http import HttpResponse, HttpResponseNotAllowed
 from django.shortcuts import  render, redirect
 from django.template.loader import render_to_string
@@ -6,8 +9,6 @@ from django.contrib.admin.views.decorators import staff_member_required
 from django.views.decorators.csrf import csrf_exempt
 from django.http import JsonResponse
 from django.conf import settings
-import subprocess
-import requests
 # import socket
 
 from monitcollector.models import collect_data, Server, Process, System
@@ -57,13 +58,21 @@ def server(request, server_id):
             {
                 'server': server,
                 'system':system,
-                'system_load_zip': list(zip(system.load_avg01, system.load_avg05, system.load_avg15)),
-                'system_cpu_zip': list(zip(system.cpu_user, system.cpu_system, system.cpu_wait)),
+                'system_load_zip': list(zip(
+                    json.loads(system.load_avg01),
+                    json.loads(system.load_avg05),
+                    json.loads(system.load_avg15)
+                )),
+                'system_cpu_zip': list(zip(
+                    json.loads(system.cpu_user),
+                    json.loads(system.cpu_system),
+                    json.loads(system.cpu_wait)
+                )),
                 'system_mem_zip': list(zip(
-                    system.memory_percent,
-                    (k/10**6 for k in system.memory_kilobyte),
-                    system.swap_percent,
-                    (k/10**6 for k in system.swap_kilobyte)
+                    json.loads(system.memory_percent),
+                    (int(k)/10**6 for k in json.loads(system.memory_kilobyte)),
+                    json.loads(system.swap_percent),
+                    (int(k)/10**6 for k in json.loads(system.swap_kilobyte))
                 )),
                 'processes':processes,
                 'monit_update_period': monit_update_period

--- a/src/monitcollector/views.py
+++ b/src/monitcollector/views.py
@@ -68,7 +68,7 @@ def server(request, server_id):
                     json.loads(system.cpu_system),
                     json.loads(system.cpu_wait)
                 )),
-                'system_mem_zip': list(zip(
+                'system_memory_zip': list(zip(
                     json.loads(system.memory_percent),
                     (int(k)/10**6 for k in json.loads(system.memory_kilobyte)),
                     json.loads(system.swap_percent),

--- a/src/monitcollector/views.py
+++ b/src/monitcollector/views.py
@@ -58,22 +58,28 @@ def server(request, server_id):
             {
                 'server': server,
                 'system':system,
-                'system_load_zip': list(zip(
-                    json.loads(system.load_avg01),
-                    json.loads(system.load_avg05),
-                    json.loads(system.load_avg15)
-                )),
-                'system_cpu_zip': list(zip(
-                    json.loads(system.cpu_user),
-                    json.loads(system.cpu_system),
-                    json.loads(system.cpu_wait)
-                )),
-                'system_memory_zip': list(zip(
-                    json.loads(system.memory_percent),
-                    (int(k)/10**6 for k in json.loads(system.memory_kilobyte)),
-                    json.loads(system.swap_percent),
-                    (int(k)/10**6 for k in json.loads(system.swap_kilobyte))
-                )),
+                'system_load_zip': [
+                    list(z) for z in zip(
+                        json.loads(system.load_avg01),
+                        json.loads(system.load_avg05),
+                        json.loads(system.load_avg15)
+                    )
+                ],
+                'system_cpu_zip': [
+                    list(z) for z in zip(
+                        json.loads(system.cpu_user),
+                        json.loads(system.cpu_system),
+                        json.loads(system.cpu_wait)
+                    )
+                ],
+                'system_memory_zip': [
+                    list(z) for z in zip(
+                        json.loads(system.memory_percent),
+                        (int(k)/10**6 for k in json.loads(system.memory_kilobyte)),
+                        json.loads(system.swap_percent),
+                        (int(k)/10**6 for k in json.loads(system.swap_kilobyte))
+                    )
+                ],
                 'processes':processes,
                 'monit_update_period': monit_update_period
             }

--- a/src/monitcollector/views.py
+++ b/src/monitcollector/views.py
@@ -57,14 +57,14 @@ def server(request, server_id):
             {
                 'server': server,
                 'system':system,
-                'system_load_zip': zip(system.load_avg01, system.load_avg05, system.load_avg15),
-                'system_cpu_zip': zip(system.cpu_user, system.cpu_system, system.cpu_wait),
-                'system_mem_zip': zip(
+                'system_load_zip': list(zip(system.load_avg01, system.load_avg05, system.load_avg15)),
+                'system_cpu_zip': list(zip(system.cpu_user, system.cpu_system, system.cpu_wait)),
+                'system_mem_zip': list(zip(
                     system.memory_percent,
                     (k/10**6 for k in system.memory_kilobyte),
                     system.swap_percent,
                     (k/10**6 for k in system.swap_kilobyte)
-                ),
+                )),
                 'processes':processes,
                 'monit_update_period': monit_update_period
             }

--- a/src/monitcollector/views.py
+++ b/src/monitcollector/views.py
@@ -57,6 +57,14 @@ def server(request, server_id):
             {
                 'server': server,
                 'system':system,
+                'system_load_zip': zip(system.load_avg01, system.load_avg05, system.load_avg15),
+                'system_cpu_zip': zip(system.cpu_user, system.cpu_system, system.cpu_wait),
+                'system_mem_zip': zip(
+                    system.memory_percent,
+                    (k/10**6 for k in system.memory_kilobyte),
+                    system.swap_percent,
+                    (k/10**6 for k in system.swap_kilobyte)
+                ),
                 'processes':processes,
                 'monit_update_period': monit_update_period
             }


### PR DESCRIPTION
With 10k of data points the current JavaScript implementation was slow: it created an empty list of data points such as `data_cpu`, `data_load`, `data_mem` and populated them with lists. It's way faster to do it on Python side using the `zip` function and just render the lists on the HTML side.
Also it's sufficient to create `new Date` objects only once and then reuse them. On the JS side we just insert the date objects into lists using the native `unshift` function.
Overall speedup is from around 30 seconds to 2.5 seconds on my laptop, with 10k data points.